### PR TITLE
Allow FarmControl to affect non-living entities with 'remove' Action.…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ repositories {
     maven {
         url = 'https://repo.codemc.org/repository/maven-public/'
     }
+    maven {
+        url = 'https://jitpack.io'
+    }
 }
 
 dependencies {
@@ -35,7 +38,7 @@ dependencies {
     compileOnly 'dev.folia:folia-api:1.19.4-R0.1-SNAPSHOT'
     compileOnly 'me.clip:placeholderapi:2.10.9'
     implementation 'org.jooq:joor-java-8:0.9.14'
-    implementation 'com.froobworld:nab-configuration:1.0.2'
+    implementation 'com.github.froobynooby:nab-configuration:master-SNAPSHOT' //'com.froobworld:nab-configuration:1.0.2'
     implementation 'org.bstats:bstats-bukkit:2.2.1'
 }
 

--- a/src/main/java/com/froobworld/farmcontrol/command/StatusCommand.java
+++ b/src/main/java/com/froobworld/farmcontrol/command/StatusCommand.java
@@ -10,6 +10,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/froobworld/farmcontrol/command/StatusCommand.java
+++ b/src/main/java/com/froobworld/farmcontrol/command/StatusCommand.java
@@ -1,6 +1,7 @@
 package com.froobworld.farmcontrol.command;
 
 import com.froobworld.farmcontrol.FarmControl;
+import com.froobworld.farmcontrol.controller.FarmController;
 import com.froobworld.farmcontrol.data.FcData;
 import com.froobworld.farmcontrol.hook.scheduler.ScheduledTask;
 import org.bukkit.Bukkit;
@@ -47,7 +48,7 @@ public class StatusCommand implements CommandExecutor {
         Map<String, AtomicInteger> actionCount = new HashMap<>();
 
         CompletableFuture<Void> completableFuture = CompletableFuture.completedFuture(null);
-        for (Entity entity : world.getEntitiesByClasses(Mob.class, Vehicle.class, Projectile.class, Item.class)) {
+        for (Entity entity : world.getEntitiesByClasses(FarmController.ENTITY_CLASSES)) {
             entityCount.incrementAndGet();
             CompletableFuture<Void> entityFuture = new CompletableFuture();
             ScheduledTask scheduledTask = farmControl.getHookManager().getSchedulerHook().runEntityTaskAsap(() -> {

--- a/src/main/java/com/froobworld/farmcontrol/command/StatusCommand.java
+++ b/src/main/java/com/froobworld/farmcontrol/command/StatusCommand.java
@@ -9,6 +9,7 @@ import org.bukkit.World;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -48,7 +49,7 @@ public class StatusCommand implements CommandExecutor {
         Map<String, AtomicInteger> actionCount = new HashMap<>();
 
         CompletableFuture<Void> completableFuture = CompletableFuture.completedFuture(null);
-        for (LivingEntity entity : world.getLivingEntities()) {
+        for (Entity entity : world.getEntities()) {
             entityCount.incrementAndGet();
             CompletableFuture<Void> entityFuture = new CompletableFuture();
             ScheduledTask scheduledTask = farmControl.getHookManager().getSchedulerHook().runEntityTaskAsap(() -> {

--- a/src/main/java/com/froobworld/farmcontrol/command/StatusCommand.java
+++ b/src/main/java/com/froobworld/farmcontrol/command/StatusCommand.java
@@ -9,10 +9,7 @@ import org.bukkit.World;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Item;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Player;
+import org.bukkit.entity.*;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
@@ -50,7 +47,7 @@ public class StatusCommand implements CommandExecutor {
         Map<String, AtomicInteger> actionCount = new HashMap<>();
 
         CompletableFuture<Void> completableFuture = CompletableFuture.completedFuture(null);
-        for (Entity entity : world.getEntities()) {
+        for (Entity entity : world.getEntitiesByClasses(Mob.class, Vehicle.class, Projectile.class, Item.class)) {
             entityCount.incrementAndGet();
             CompletableFuture<Void> entityFuture = new CompletableFuture();
             ScheduledTask scheduledTask = farmControl.getHookManager().getSchedulerHook().runEntityTaskAsap(() -> {

--- a/src/main/java/com/froobworld/farmcontrol/controller/CompatibilityListener.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/CompatibilityListener.java
@@ -42,6 +42,9 @@ public class CompatibilityListener implements Listener {
 
     @EventHandler
     public void onEntityTarget(EntityTargetLivingEntityEvent event) {
+        if (event.getTarget() == null) {
+            return;
+        }
         Actioner.undoActions(event.getTarget(), action -> {
             return farmControl.getFcConfig().worldSettings.of(event.getEntity().getWorld()).actionSettings.undoOn.of(action).target.get();
         }, farmControl);

--- a/src/main/java/com/froobworld/farmcontrol/controller/FarmController.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/FarmController.java
@@ -17,8 +17,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.List;
 
 public class FarmController {
+    public static final Class<?>[] ENTITY_CLASSES = List.of(Mob.class, Vehicle.class, Projectile.class, Item.class).toArray(new Class[0]);
     private final FarmControl farmControl;
     private final CycleHistoryManager cycleHistoryManager;
     private final Map<World, Map<Trigger, Set<ActionProfile>>> worldTriggerProfilesMap = new HashMap<>();
@@ -86,7 +88,7 @@ public class FarmController {
 
     public void removeWorld(World world) {
         worldTriggerProfilesMap.remove(world);
-        for (Entity entity : world.getEntitiesByClasses(Mob.class, Vehicle.class, Projectile.class, Item.class)) {
+        for (Entity entity : world.getEntities()) {
             farmControl.getHookManager().getSchedulerHook().runEntityTaskAsap(
                     () -> Actioner.undoAllActions(entity, farmControl),
                     null, entity);

--- a/src/main/java/com/froobworld/farmcontrol/controller/FarmController.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/FarmController.java
@@ -1,7 +1,9 @@
 package com.froobworld.farmcontrol.controller;
 
 import com.froobworld.farmcontrol.FarmControl;
-import com.froobworld.farmcontrol.controller.task.*;
+import com.froobworld.farmcontrol.controller.task.ActionPerformTask;
+import com.froobworld.farmcontrol.controller.task.TriggerCheckTask;
+import com.froobworld.farmcontrol.controller.task.UntriggerPerformTask;
 import com.froobworld.farmcontrol.controller.tracker.CycleHistoryManager;
 import com.froobworld.farmcontrol.controller.trigger.Trigger;
 import com.froobworld.farmcontrol.hook.scheduler.RegionisedSchedulerHook;
@@ -11,7 +13,10 @@ import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public class FarmController {
     private final FarmControl farmControl;
@@ -81,7 +86,7 @@ public class FarmController {
 
     public void removeWorld(World world) {
         worldTriggerProfilesMap.remove(world);
-        for (Entity entity : world.getLivingEntities()) {
+        for (Entity entity : world.getEntities()) {
             farmControl.getHookManager().getSchedulerHook().runEntityTaskAsap(
                     () -> Actioner.undoAllActions(entity, farmControl),
                     null, entity);

--- a/src/main/java/com/froobworld/farmcontrol/controller/FarmController.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/FarmController.java
@@ -11,7 +11,7 @@ import com.froobworld.farmcontrol.hook.scheduler.ScheduledTask;
 import com.froobworld.farmcontrol.utils.Actioner;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
-import org.bukkit.entity.Entity;
+import org.bukkit.entity.*;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -86,7 +86,7 @@ public class FarmController {
 
     public void removeWorld(World world) {
         worldTriggerProfilesMap.remove(world);
-        for (Entity entity : world.getEntities()) {
+        for (Entity entity : world.getEntitiesByClasses(Mob.class, Vehicle.class, Projectile.class, Item.class)) {
             farmControl.getHookManager().getSchedulerHook().runEntityTaskAsap(
                     () -> Actioner.undoAllActions(entity, farmControl),
                     null, entity);

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/Action.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/Action.java
@@ -1,5 +1,6 @@
 package com.froobworld.farmcontrol.controller.action;
 
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Mob;
 
 public abstract class Action {
@@ -34,7 +35,7 @@ public abstract class Action {
         return undoOnUnload;
     }
 
-    public abstract void doAction(Mob mob);
+    public abstract void doAction(Entity entity);
 
     public abstract void undoAction(Mob mob);
 }

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/Action.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/Action.java
@@ -1,24 +1,23 @@
 package com.froobworld.farmcontrol.controller.action;
 
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.Mob;
 
 public abstract class Action {
     private final String name;
+    private final Class<?> entityClass;
     private final boolean removes;
     private final boolean persistent;
     private final boolean undoOnUnload;
-    private final Class<?> entityClass;
 
-    public Action(String name, boolean removes, boolean persistent, boolean undoOnUnload, Class<?> entityClass) {
+    public Action(String name, Class<?> entityClass, boolean removes, boolean persistent, boolean undoOnUnload) {
         if (!name.matches("[a-z-]+")) {
             throw new IllegalArgumentException("Name must match [a-z-]+");
         }
+        this.entityClass = entityClass;
         this.name = name;
         this.removes = removes;
         this.persistent = persistent;
         this.undoOnUnload = undoOnUnload;
-        this.entityClass = entityClass;
     }
 
     public final String getName() {

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/Action.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/Action.java
@@ -8,8 +8,9 @@ public abstract class Action {
     private final boolean removes;
     private final boolean persistent;
     private final boolean undoOnUnload;
+    private final Class<?> entityClass;
 
-    public Action(String name, boolean removes, boolean persistent, boolean undoOnUnload) {
+    public Action(String name, boolean removes, boolean persistent, boolean undoOnUnload, Class<?> entityClass) {
         if (!name.matches("[a-z-]+")) {
             throw new IllegalArgumentException("Name must match [a-z-]+");
         }
@@ -17,6 +18,7 @@ public abstract class Action {
         this.removes = removes;
         this.persistent = persistent;
         this.undoOnUnload = undoOnUnload;
+        this.entityClass = entityClass;
     }
 
     public final String getName() {
@@ -38,4 +40,8 @@ public abstract class Action {
     public abstract void doAction(Entity entity);
 
     public abstract void undoAction(Entity entity);
+
+    public Class<?> getEntityClass() {
+        return entityClass;
+    }
 }

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/Action.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/Action.java
@@ -37,5 +37,5 @@ public abstract class Action {
 
     public abstract void doAction(Entity entity);
 
-    public abstract void undoAction(Mob mob);
+    public abstract void undoAction(Entity entity);
 }

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/DisableBreedingAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/DisableBreedingAction.java
@@ -8,7 +8,7 @@ public class DisableBreedingAction extends Action {
     private final BreedingBlocker breedingBlocker;
 
     public DisableBreedingAction(BreedingBlocker breedingBlocker) {
-        super("disable-breeding", false, true, false);
+        super("disable-breeding", false, true, false, Mob.class);
         this.breedingBlocker = breedingBlocker;
     }
 

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/DisableBreedingAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/DisableBreedingAction.java
@@ -17,12 +17,14 @@ public class DisableBreedingAction extends Action {
         if (!(entity instanceof Mob)) {
             return;
         }
-
         breedingBlocker.setBreedingDisabled(entity, true);
     }
 
     @Override
-    public void undoAction(Mob mob) {
+    public void undoAction(Entity entity) {
+        if (!(entity instanceof Mob mob)) {
+            return;
+        }
         breedingBlocker.setBreedingDisabled(mob, false);
     }
 }

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/DisableBreedingAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/DisableBreedingAction.java
@@ -8,7 +8,7 @@ public class DisableBreedingAction extends Action {
     private final BreedingBlocker breedingBlocker;
 
     public DisableBreedingAction(BreedingBlocker breedingBlocker) {
-        super("disable-breeding", false, true, false, Mob.class);
+        super("disable-breeding", Mob.class, false, true, false);
         this.breedingBlocker = breedingBlocker;
     }
 

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/DisableBreedingAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/DisableBreedingAction.java
@@ -1,6 +1,7 @@
 package com.froobworld.farmcontrol.controller.action;
 
 import com.froobworld.farmcontrol.controller.breeding.BreedingBlocker;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Mob;
 
 public class DisableBreedingAction extends Action {
@@ -12,8 +13,12 @@ public class DisableBreedingAction extends Action {
     }
 
     @Override
-    public void doAction(Mob mob) {
-        breedingBlocker.setBreedingDisabled(mob, true);
+    public void doAction(Entity entity) {
+        if (!(entity instanceof Mob)) {
+            return;
+        }
+
+        breedingBlocker.setBreedingDisabled(entity, true);
     }
 
     @Override

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/DisableCollisionsAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/DisableCollisionsAction.java
@@ -19,7 +19,10 @@ public class DisableCollisionsAction extends Action {
     }
 
     @Override
-    public void undoAction(Mob mob) {
+    public void undoAction(Entity entity) {
+        if (!(entity instanceof Mob mob)) {
+            return;
+        }
         mob.setCollidable(true);
     }
 }

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/DisableCollisionsAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/DisableCollisionsAction.java
@@ -6,7 +6,7 @@ import org.bukkit.entity.Mob;
 public class DisableCollisionsAction extends Action {
 
     public DisableCollisionsAction() {
-        super("disable-collisions", false, false, true);
+        super("disable-collisions", false, false, true, Mob.class);
     }
 
     @Override

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/DisableCollisionsAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/DisableCollisionsAction.java
@@ -1,5 +1,6 @@
 package com.froobworld.farmcontrol.controller.action;
 
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Mob;
 
 public class DisableCollisionsAction extends Action {
@@ -9,8 +10,12 @@ public class DisableCollisionsAction extends Action {
     }
 
     @Override
-    public void doAction(Mob mob) {
-        mob.setCollidable(false);
+    public void doAction(Entity entity) {
+        if (!(entity instanceof Mob ent)) {
+            return;
+        }
+
+        ent.setCollidable(false);
     }
 
     @Override

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/DisableCollisionsAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/DisableCollisionsAction.java
@@ -6,16 +6,16 @@ import org.bukkit.entity.Mob;
 public class DisableCollisionsAction extends Action {
 
     public DisableCollisionsAction() {
-        super("disable-collisions", false, false, true, Mob.class);
+        super("disable-collisions", Mob.class, false, false, true);
     }
 
     @Override
     public void doAction(Entity entity) {
-        if (!(entity instanceof Mob ent)) {
+        if (!(entity instanceof Mob mob)) {
             return;
         }
 
-        ent.setCollidable(false);
+        mob.setCollidable(false);
     }
 
     @Override

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/KillAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/KillAction.java
@@ -1,5 +1,6 @@
 package com.froobworld.farmcontrol.controller.action;
 
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Mob;
 
 public class KillAction extends Action {
@@ -9,8 +10,12 @@ public class KillAction extends Action {
     }
 
     @Override
-    public void doAction(Mob mob) {
-        mob.setHealth(0);
+    public void doAction(Entity entity) {
+        if (!(entity instanceof Mob ent)) {
+            return;
+        }
+
+        ent.setHealth(0);
     }
 
     @Override

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/KillAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/KillAction.java
@@ -6,7 +6,7 @@ import org.bukkit.entity.Mob;
 public class KillAction extends Action {
 
     public KillAction() {
-        super("kill", true, false, false);
+        super("kill", true, false, false, Mob.class);
     }
 
     @Override

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/KillAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/KillAction.java
@@ -11,13 +11,12 @@ public class KillAction extends Action {
 
     @Override
     public void doAction(Entity entity) {
-        if (!(entity instanceof Mob ent)) {
+        if (!(entity instanceof Mob mob)) {
             return;
         }
-
-        ent.setHealth(0);
+        mob.setHealth(0);
     }
 
     @Override
-    public void undoAction(Mob mob) {}
+    public void undoAction(Entity entity) {}
 }

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/KillAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/KillAction.java
@@ -6,7 +6,7 @@ import org.bukkit.entity.Mob;
 public class KillAction extends Action {
 
     public KillAction() {
-        super("kill", true, false, false, Mob.class);
+        super("kill", Mob.class, true, false, false);
     }
 
     @Override

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAction.java
@@ -1,12 +1,11 @@
 package com.froobworld.farmcontrol.controller.action;
 
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.Mob;
 
 public class RemoveAction extends Action {
 
     public RemoveAction() {
-        super("remove", true, false, false, Entity.class);
+        super("remove", Entity.class, true, false, false);
     }
 
     @Override

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAction.java
@@ -6,7 +6,7 @@ import org.bukkit.entity.Mob;
 public class RemoveAction extends Action {
 
     public RemoveAction() {
-        super("remove", true, false, false);
+        super("remove", true, false, false, Entity.class);
     }
 
     @Override

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAction.java
@@ -15,5 +15,5 @@ public class RemoveAction extends Action {
     }
 
     @Override
-    public void undoAction(Mob mob) {}
+    public void undoAction(Entity entity) {}
 }

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAction.java
@@ -1,5 +1,6 @@
 package com.froobworld.farmcontrol.controller.action;
 
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Mob;
 
 public class RemoveAction extends Action {
@@ -9,8 +10,8 @@ public class RemoveAction extends Action {
     }
 
     @Override
-    public void doAction(Mob mob) {
-        mob.remove();
+    public void doAction(Entity entity) {
+        entity.remove();
     }
 
     @Override

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAiAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAiAction.java
@@ -7,7 +7,7 @@ import org.bukkit.util.Vector;
 public class RemoveAiAction extends Action {
 
     public RemoveAiAction() {
-        super("remove-ai", false, true, true, Mob.class);
+        super("remove-ai", Mob.class, false, true, true);
     }
 
     @Override

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAiAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAiAction.java
@@ -1,5 +1,6 @@
 package com.froobworld.farmcontrol.controller.action;
 
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Mob;
 import org.bukkit.util.Vector;
 
@@ -10,7 +11,10 @@ public class RemoveAiAction extends Action {
     }
 
     @Override
-    public void doAction(Mob mob) {
+    public void doAction(Entity entity) {
+        if (!(entity instanceof Mob mob)) {
+            return;
+        }
         mob.setAI(false);
     }
 

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAiAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAiAction.java
@@ -19,7 +19,10 @@ public class RemoveAiAction extends Action {
     }
 
     @Override
-    public void undoAction(Mob mob) {
+    public void undoAction(Entity entity) {
+        if (!(entity instanceof Mob mob)) {
+            return;
+        }
         mob.setAI(true);
         mob.setVelocity(new Vector(0, 0, 0));
     }

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAiAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAiAction.java
@@ -7,7 +7,7 @@ import org.bukkit.util.Vector;
 public class RemoveAiAction extends Action {
 
     public RemoveAiAction() {
-        super("remove-ai", false, true, true);
+        super("remove-ai", false, true, true, Mob.class);
     }
 
     @Override

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAwarenessAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAwarenessAction.java
@@ -6,7 +6,7 @@ import org.bukkit.entity.Mob;
 public class RemoveAwarenessAction extends Action {
 
     public RemoveAwarenessAction() {
-        super("remove-awareness", false, true, true, Mob.class);
+        super("remove-awareness", Mob.class, false, true, true);
     }
 
     @Override

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAwarenessAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAwarenessAction.java
@@ -1,5 +1,6 @@
 package com.froobworld.farmcontrol.controller.action;
 
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Mob;
 
 public class RemoveAwarenessAction extends Action {
@@ -9,7 +10,10 @@ public class RemoveAwarenessAction extends Action {
     }
 
     @Override
-    public void doAction(Mob mob) {
+    public void doAction(Entity entity) {
+        if (!(entity instanceof Mob mob)) {
+            return;
+        }
         mob.setAware(false);
     }
 

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAwarenessAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAwarenessAction.java
@@ -6,7 +6,7 @@ import org.bukkit.entity.Mob;
 public class RemoveAwarenessAction extends Action {
 
     public RemoveAwarenessAction() {
-        super("remove-awareness", false, true, true);
+        super("remove-awareness", false, true, true, Mob.class);
     }
 
     @Override

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAwarenessAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveAwarenessAction.java
@@ -18,7 +18,10 @@ public class RemoveAwarenessAction extends Action {
     }
 
     @Override
-    public void undoAction(Mob mob) {
+    public void undoAction(Entity entity) {
+        if (!(entity instanceof Mob mob)) {
+            return;
+        }
         mob.setAware(true);
     }
 }

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveRandomMovementAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveRandomMovementAction.java
@@ -30,7 +30,7 @@ public class RemoveRandomMovementAction extends Action {
     }
 
     public RemoveRandomMovementAction() {
-        super("remove-random-movement", false, false, true);
+        super("remove-random-movement", false, false, true, Mob.class);
     }
 
     @Override

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveRandomMovementAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveRandomMovementAction.java
@@ -30,7 +30,7 @@ public class RemoveRandomMovementAction extends Action {
     }
 
     public RemoveRandomMovementAction() {
-        super("remove-random-movement", false, false, true, Mob.class);
+        super("remove-random-movement", Mob.class, false, false, true);
     }
 
     @Override

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveRandomMovementAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveRandomMovementAction.java
@@ -60,7 +60,10 @@ public class RemoveRandomMovementAction extends Action {
     }
 
     @Override
-    public void undoAction(Mob mob) {
+    public void undoAction(Entity entity) {
+        if (!(entity instanceof Mob mob)) {
+            return;
+        }
         Object entityObject = on(mob).call("getHandle").get();
         Set<Object> wrappedGoals = on(entityObject)
                 .field(NmsUtils.GoalSelectorHelper.getGoalSelectorFieldName())

--- a/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveRandomMovementAction.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/action/RemoveRandomMovementAction.java
@@ -3,6 +3,7 @@ package com.froobworld.farmcontrol.controller.action;
 import com.froobworld.farmcontrol.utils.NmsUtils;
 import com.google.common.collect.MapMaker;
 import com.google.common.collect.Sets;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Mob;
 
 import java.util.*;
@@ -33,7 +34,11 @@ public class RemoveRandomMovementAction extends Action {
     }
 
     @Override
-    public void doAction(Mob mob) {
+    public void doAction(Entity entity) {
+        if (!(entity instanceof Mob mob)) {
+            return;
+        }
+
         Object entityObject = on(mob).call("getHandle").get();
         Set<?> wrappedGoals = on(entityObject)
                 .field(NmsUtils.GoalSelectorHelper.getGoalSelectorFieldName())

--- a/src/main/java/com/froobworld/farmcontrol/controller/entity/SnapshotEntity.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/entity/SnapshotEntity.java
@@ -19,7 +19,6 @@ public class SnapshotEntity {
     private final boolean customName;
     private final boolean tamed;
     private final boolean isPatrolLeader;
-    private final boolean isMob;
     private final int ticksLived;
     private final List<Object> classifications = new ArrayList<>();
 
@@ -33,7 +32,6 @@ public class SnapshotEntity {
         this.customName = entity.getCustomName() != null;
         this.tamed = entity instanceof Tameable && ((Tameable) entity).isTamed();
         this.isPatrolLeader = entity instanceof Raider && ((Raider) entity).isPatrolLeader();
-        this.isMob = entity instanceof Mob;
         this.ticksLived = entity.getTicksLived();
         classifications.add(entity.getType());
         if (entity instanceof Colorable) {
@@ -103,7 +101,4 @@ public class SnapshotEntity {
         return classifications;
     }
 
-    public boolean isMob() {
-        return isMob;
-    }
 }

--- a/src/main/java/com/froobworld/farmcontrol/controller/entity/SnapshotEntity.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/entity/SnapshotEntity.java
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class SnapshotEntity {
-    private final Mob entity;
+    private final Entity entity;
     private final int entityId;
     private final Vector location;
     private final FcData fcData;
@@ -19,19 +19,21 @@ public class SnapshotEntity {
     private final boolean customName;
     private final boolean tamed;
     private final boolean isPatrolLeader;
+    private final boolean isMob;
     private final int ticksLived;
     private final List<Object> classifications = new ArrayList<>();
 
-    public SnapshotEntity(Mob entity) {
+    public SnapshotEntity(Entity entity) {
         this.entity = entity;
         this.entityId = entity.getEntityId();
         this.location = entity.getLocation().toVector();
         this.fcData = FcData.get(entity);
-        this.leashed = entity.isLeashed();
+        this.leashed = entity instanceof Mob && ((Mob) entity).isLeashed();
         this.loveMode = entity instanceof Animals && ((Animals) entity).isLoveMode();
         this.customName = entity.getCustomName() != null;
         this.tamed = entity instanceof Tameable && ((Tameable) entity).isTamed();
         this.isPatrolLeader = entity instanceof Raider && ((Raider) entity).isPatrolLeader();
+        this.isMob = entity instanceof Mob;
         this.ticksLived = entity.getTicksLived();
         classifications.add(entity.getType());
         if (entity instanceof Colorable) {
@@ -45,7 +47,7 @@ public class SnapshotEntity {
         }
     }
 
-    public Class<? extends Mob> getEntityClass() {
+    public Class<? extends Entity> getEntityClass() {
         return entity.getClass();
     }
 
@@ -65,7 +67,7 @@ public class SnapshotEntity {
         return fcData;
     }
 
-    public Mob getEntity() {
+    public Entity getEntity() {
         return entity;
     }
 
@@ -99,5 +101,9 @@ public class SnapshotEntity {
 
     public List<Object> getClassifications() {
         return classifications;
+    }
+
+    public boolean isMob() {
+        return isMob;
     }
 }

--- a/src/main/java/com/froobworld/farmcontrol/controller/task/ActionAllocationTask.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/task/ActionAllocationTask.java
@@ -68,6 +68,9 @@ public class ActionAllocationTask implements Runnable {
                     Set<TriggerActionPair> triggerActionPairs = triggerActionMap.computeIfAbsent(next, e -> new HashSet<>());
                     Set<TriggerActionPair> unTriggerActionPairs = unTriggerActionMap.getOrDefault(next, Collections.emptySet());
                     for (Action action : triggerProfilePair.actionProfile.getActions()) {
+                        if (!action.getEntityClass().isAssignableFrom(next.getEntityClass())) {
+                            continue;
+                        }
                         TriggerActionPair triggerActionPair = new TriggerActionPair(triggerProfilePair.trigger, action);
                         triggerActionPairs.add(triggerActionPair);
                         unTriggerActionPairs.remove(triggerActionPair);

--- a/src/main/java/com/froobworld/farmcontrol/controller/task/ActionPerformTask.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/task/ActionPerformTask.java
@@ -7,6 +7,7 @@ import com.froobworld.farmcontrol.controller.entity.SnapshotEntity;
 import com.froobworld.farmcontrol.hook.scheduler.ScheduledTask;
 import com.froobworld.farmcontrol.hook.scheduler.SchedulerHook;
 import org.bukkit.World;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Mob;
 
 import java.util.Map;
@@ -32,7 +33,7 @@ public class ActionPerformTask implements Runnable {
     public void run() {
         CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
         for (SnapshotEntity snapshotEntity : triggerActionMap.keySet()) {
-            Mob entity = snapshotEntity.getEntity();
+            Entity entity = snapshotEntity.getEntity();
             CompletableFuture<Void> entityFuture = new CompletableFuture<>();
             ScheduledTask scheduledTask = schedulerHook.runEntityTaskAsap(() -> {
                 try {
@@ -57,9 +58,9 @@ public class ActionPerformTask implements Runnable {
             }
         }
         for (SnapshotEntity snapshotEntity : unTriggerActionMap.keySet()) {
-            Mob entity = snapshotEntity.getEntity();
+            Entity entity = snapshotEntity.getEntity();
             schedulerHook.runEntityTaskAsap(() -> {
-                if (!entity.isValid()) {
+                if (!(entity instanceof Mob mob) || !entity.isValid()) {
                     return;
                 }
                 FcData fcData = snapshotEntity.getFcData();
@@ -69,7 +70,7 @@ public class ActionPerformTask implements Runnable {
                 Set<TriggerActionPair> triggerActionPairs = unTriggerActionMap.get(snapshotEntity);
                 for (TriggerActionPair triggerActionPair : triggerActionPairs) {
                     if (fcData.remove(triggerActionPair.trigger, triggerActionPair.action)) {
-                        triggerActionPair.action.undoAction(entity);
+                        triggerActionPair.action.undoAction(mob);
                     }
                 }
                 fcData.save(entity);

--- a/src/main/java/com/froobworld/farmcontrol/controller/task/ActionPerformTask.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/task/ActionPerformTask.java
@@ -8,7 +8,6 @@ import com.froobworld.farmcontrol.hook.scheduler.ScheduledTask;
 import com.froobworld.farmcontrol.hook.scheduler.SchedulerHook;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.Mob;
 
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/com/froobworld/farmcontrol/controller/task/ActionPerformTask.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/task/ActionPerformTask.java
@@ -60,7 +60,7 @@ public class ActionPerformTask implements Runnable {
         for (SnapshotEntity snapshotEntity : unTriggerActionMap.keySet()) {
             Entity entity = snapshotEntity.getEntity();
             schedulerHook.runEntityTaskAsap(() -> {
-                if (!(entity instanceof Mob mob) || !entity.isValid()) {
+                if (!entity.isValid()) {
                     return;
                 }
                 FcData fcData = snapshotEntity.getFcData();
@@ -70,7 +70,7 @@ public class ActionPerformTask implements Runnable {
                 Set<TriggerActionPair> triggerActionPairs = unTriggerActionMap.get(snapshotEntity);
                 for (TriggerActionPair triggerActionPair : triggerActionPairs) {
                     if (fcData.remove(triggerActionPair.trigger, triggerActionPair.action)) {
-                        triggerActionPair.action.undoAction(mob);
+                        triggerActionPair.action.undoAction(entity);
                     }
                 }
                 fcData.save(entity);

--- a/src/main/java/com/froobworld/farmcontrol/controller/task/TriggerCheckTask.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/task/TriggerCheckTask.java
@@ -62,7 +62,7 @@ public class TriggerCheckTask implements Runnable {
             List<SnapshotEntity> snapshotEntities = new ArrayList<>();
             CompletableFuture<Void> completableFuture = CompletableFuture.completedFuture(null);
             if (!profilesToRun.isEmpty() || !untriggerStrategyMap.isEmpty()) {
-                for (Entity entity : world.getEntitiesByClasses(Mob.class, Vehicle.class, Projectile.class, Item.class)) {
+                for (Entity entity : world.getEntitiesByClasses(FarmController.ENTITY_CLASSES)) {
                     CompletableFuture<Void> entityFuture = new CompletableFuture<>();
                     ScheduledTask scheduledTask = farmControl.getHookManager().getSchedulerHook().runEntityTaskAsap(() -> {
                         try {

--- a/src/main/java/com/froobworld/farmcontrol/controller/task/TriggerCheckTask.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/task/TriggerCheckTask.java
@@ -10,6 +10,7 @@ import com.froobworld.farmcontrol.controller.trigger.UntriggerStrategy;
 import com.froobworld.farmcontrol.hook.scheduler.ScheduledTask;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.bukkit.World;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Mob;
 
 import java.util.*;
@@ -62,7 +63,7 @@ public class TriggerCheckTask implements Runnable {
             List<SnapshotEntity> snapshotEntities = new ArrayList<>();
             CompletableFuture<Void> completableFuture = CompletableFuture.completedFuture(null);
             if (!profilesToRun.isEmpty() || !untriggerStrategyMap.isEmpty()) {
-                for (Mob entity : world.getEntitiesByClass(Mob.class)) {
+                for (Entity entity : world.getEntities()) {
                     CompletableFuture<Void> entityFuture = new CompletableFuture<>();
                     ScheduledTask scheduledTask = farmControl.getHookManager().getSchedulerHook().runEntityTaskAsap(() -> {
                         try {

--- a/src/main/java/com/froobworld/farmcontrol/controller/task/TriggerCheckTask.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/task/TriggerCheckTask.java
@@ -10,9 +10,7 @@ import com.froobworld.farmcontrol.controller.trigger.UntriggerStrategy;
 import com.froobworld.farmcontrol.hook.scheduler.ScheduledTask;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.bukkit.World;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Item;
-import org.bukkit.entity.Mob;
+import org.bukkit.entity.*;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -64,7 +62,7 @@ public class TriggerCheckTask implements Runnable {
             List<SnapshotEntity> snapshotEntities = new ArrayList<>();
             CompletableFuture<Void> completableFuture = CompletableFuture.completedFuture(null);
             if (!profilesToRun.isEmpty() || !untriggerStrategyMap.isEmpty()) {
-                for (Entity entity : world.getEntities()) {
+                for (Entity entity : world.getEntitiesByClasses(Mob.class, Vehicle.class, Projectile.class, Item.class)) {
                     CompletableFuture<Void> entityFuture = new CompletableFuture<>();
                     ScheduledTask scheduledTask = farmControl.getHookManager().getSchedulerHook().runEntityTaskAsap(() -> {
                         try {

--- a/src/main/java/com/froobworld/farmcontrol/controller/task/TriggerCheckTask.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/task/TriggerCheckTask.java
@@ -11,6 +11,7 @@ import com.froobworld.farmcontrol.hook.scheduler.ScheduledTask;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.Mob;
 
 import java.util.*;

--- a/src/main/java/com/froobworld/farmcontrol/controller/task/UntriggerPerformTask.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/task/UntriggerPerformTask.java
@@ -4,6 +4,7 @@ import com.froobworld.farmcontrol.controller.TriggerActionPair;
 import com.froobworld.farmcontrol.controller.entity.SnapshotEntity;
 import com.froobworld.farmcontrol.data.FcData;
 import com.froobworld.farmcontrol.hook.scheduler.SchedulerHook;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Mob;
 
 import java.util.Map;
@@ -21,9 +22,9 @@ public class UntriggerPerformTask implements Runnable {
     @Override
     public void run() {
         for (SnapshotEntity snapshotEntity : actionsToUndo.keySet()) {
-            Mob entity = snapshotEntity.getEntity();
+            Entity entity = snapshotEntity.getEntity();
             schedulerHook.runEntityTaskAsap(() -> {
-                if (!entity.isValid()) {
+                if (!(entity instanceof Mob mob) || !entity.isValid()) {
                     return;
                 }
                 FcData fcData = FcData.get(entity);
@@ -32,7 +33,7 @@ public class UntriggerPerformTask implements Runnable {
                 }
                 for (TriggerActionPair triggerActionPair : actionsToUndo.get(snapshotEntity)) {
                     if (fcData.remove(triggerActionPair.trigger, triggerActionPair.action)) {
-                        triggerActionPair.action.undoAction(entity);
+                        triggerActionPair.action.undoAction(mob);
                     }
                 }
                 fcData.save(entity);

--- a/src/main/java/com/froobworld/farmcontrol/group/GroupDefinition.java
+++ b/src/main/java/com/froobworld/farmcontrol/group/GroupDefinition.java
@@ -63,7 +63,7 @@ public class GroupDefinition {
         Predicate<SnapshotEntity> typePredicate = section.getStringList("types").stream()
                 .map(EntityTypeUtils::fromString)
                 .reduce(Predicate::or)
-                .orElse(snapshotEntity -> true);
+                .orElse(snapshotEntity -> false); // require explicit specification of types by defaulting to false
         Predicate<SnapshotEntity> excludeTypePredicate = section.getStringList("exclude-types").stream()
                 .map(EntityTypeUtils::fromString)
                 .reduce(Predicate::or)

--- a/src/main/java/com/froobworld/farmcontrol/utils/Actioner.java
+++ b/src/main/java/com/froobworld/farmcontrol/utils/Actioner.java
@@ -4,7 +4,6 @@ import com.froobworld.farmcontrol.FarmControl;
 import com.froobworld.farmcontrol.controller.action.Action;
 import com.froobworld.farmcontrol.data.FcData;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.Mob;
 
 import java.util.function.Predicate;
 
@@ -17,9 +16,6 @@ public final class Actioner {
     }
 
     public static void undoActions(Entity entity, Predicate<Action> actionUndoPredicate, FarmControl farmControl) {
-        if (!(entity instanceof Mob)) {
-            return;
-        }
         FcData fcData = FcData.get(entity);
         if (fcData == null) {
             return;
@@ -27,7 +23,7 @@ public final class Actioner {
         for (Action action : farmControl.getActionManager().getActions()) {
             if (actionUndoPredicate.test(action)) {
                 if (fcData.removeAction(action)) {
-                    action.undoAction((Mob) entity);
+                    action.undoAction(entity);
                 }
             }
         }

--- a/src/main/java/com/froobworld/farmcontrol/utils/EntityTypeUtils.java
+++ b/src/main/java/com/froobworld/farmcontrol/utils/EntityTypeUtils.java
@@ -26,6 +26,8 @@ public final class EntityTypeUtils {
                 return entity -> Tameable.class.isAssignableFrom(entity.getEntityClass());
             } else if (category.equalsIgnoreCase("raider")) {
                 return entity -> Raider.class.isAssignableFrom(entity.getEntityClass());
+            } else if (category.equalsIgnoreCase("vehicle")) {
+                return entity -> Vehicle.class.isAssignableFrom(entity.getEntityClass());
             }
         }
         return entity -> entity.getEntityType().toString().equalsIgnoreCase(string);

--- a/src/main/java/com/froobworld/farmcontrol/utils/EntityTypeUtils.java
+++ b/src/main/java/com/froobworld/farmcontrol/utils/EntityTypeUtils.java
@@ -12,24 +12,16 @@ public final class EntityTypeUtils {
     public static Predicate<SnapshotEntity> fromString(String string) {
         if (string.toLowerCase().startsWith("category:")) {
             String category = string.split(":")[1];
-            if (category.equalsIgnoreCase("animal")) {
-                return entity -> Animals.class.isAssignableFrom(entity.getEntityClass());
-            } else if (category.equalsIgnoreCase("monster")) {
-                return entity -> Monster.class.isAssignableFrom(entity.getEntityClass());
-            } else if (category.equalsIgnoreCase("golem")) {
-                return entity -> Golem.class.isAssignableFrom(entity.getEntityClass());
-            } else if (category.equalsIgnoreCase("ambient")) {
-                return entity -> Ambient.class.isAssignableFrom(entity.getEntityClass());
-            } else if (category.equalsIgnoreCase("fish")) {
-                return entity -> Fish.class.isAssignableFrom(entity.getEntityClass());
-            } else if (category.equalsIgnoreCase("tameable")) {
-                return entity -> Tameable.class.isAssignableFrom(entity.getEntityClass());
-            } else if (category.equalsIgnoreCase("raider")) {
-                return entity -> Raider.class.isAssignableFrom(entity.getEntityClass());
-            } else if (category.equalsIgnoreCase("vehicle")) {
-                return entity -> Vehicle.class.isAssignableFrom(entity.getEntityClass());
-            } else if (category.equalsIgnoreCase("item")) {
-                return entity -> Item.class.isAssignableFrom(entity.getEntityClass());
+            switch (category.toLowerCase()) {
+                case "animal" -> {return entity -> Animals.class.isAssignableFrom(entity.getEntityClass());}
+                case "monster" -> {return entity -> Monster.class.isAssignableFrom(entity.getEntityClass());}
+                case "golem" -> {return entity -> Golem.class.isAssignableFrom(entity.getEntityClass());}
+                case "ambient" -> {return entity -> Ambient.class.isAssignableFrom(entity.getEntityClass());}
+                case "fish" -> {return entity -> Fish.class.isAssignableFrom(entity.getEntityClass());}
+                case "tameable" -> {return entity -> Tameable.class.isAssignableFrom(entity.getEntityClass());}
+                case "raider" -> {return entity -> Raider.class.isAssignableFrom(entity.getEntityClass());}
+                case "vehicle" -> {return entity -> Vehicle.class.isAssignableFrom(entity.getEntityClass());}
+                case "projectile" -> {return entity -> Projectile.class.isAssignableFrom(entity.getEntityClass());}
             }
         }
         return entity -> entity.getEntityType().toString().equalsIgnoreCase(string);

--- a/src/main/java/com/froobworld/farmcontrol/utils/EntityTypeUtils.java
+++ b/src/main/java/com/froobworld/farmcontrol/utils/EntityTypeUtils.java
@@ -20,6 +20,7 @@ public final class EntityTypeUtils {
                 case "fish" -> {return entity -> Fish.class.isAssignableFrom(entity.getEntityClass());}
                 case "tameable" -> {return entity -> Tameable.class.isAssignableFrom(entity.getEntityClass());}
                 case "raider" -> {return entity -> Raider.class.isAssignableFrom(entity.getEntityClass());}
+                case "mob" -> {return entity -> Mob.class.isAssignableFrom(entity.getEntityClass());}
                 case "vehicle" -> {return entity -> Vehicle.class.isAssignableFrom(entity.getEntityClass());}
                 case "projectile" -> {return entity -> Projectile.class.isAssignableFrom(entity.getEntityClass());}
             }

--- a/src/main/java/com/froobworld/farmcontrol/utils/EntityTypeUtils.java
+++ b/src/main/java/com/froobworld/farmcontrol/utils/EntityTypeUtils.java
@@ -28,6 +28,8 @@ public final class EntityTypeUtils {
                 return entity -> Raider.class.isAssignableFrom(entity.getEntityClass());
             } else if (category.equalsIgnoreCase("vehicle")) {
                 return entity -> Vehicle.class.isAssignableFrom(entity.getEntityClass());
+            } else if (category.equalsIgnoreCase("item")) {
+                return entity -> Item.class.isAssignableFrom(entity.getEntityClass());
             }
         }
         return entity -> entity.getEntityType().toString().equalsIgnoreCase(string);

--- a/src/main/resources/resources/config.yml
+++ b/src/main/resources/resources/config.yml
@@ -83,6 +83,8 @@ world-settings:
 
       # Which types of mobs should we not perform actions on?
       type:
+        - chest_boat
+        - minecart_chest
       #  - villager
 
       # For which metadata should we not perform actions on a mob?


### PR DESCRIPTION
… Also adds a 'vehicle' category

I think FarmControl should not be limited to just LivingEntities/Mobs. It's a very good and diverse plugin and with a few simple changes it can be converted to support all entities for at least the 'remove' action. Hopefully you take a look at my fork and decide to add in some stuff.