### PR TITLE
feat(config): add always include types

### DIFF
--- a/src/main/java/com/froobworld/farmcontrol/config/FcConfig.java
+++ b/src/main/java/com/froobworld/farmcontrol/config/FcConfig.java
@@ -44,6 +44,9 @@ public class FcConfig extends NabConfiguration {
         @Section(key = "exclusion-settings")
         public final ExclusionSettings exclusionSettings = new ExclusionSettings();
 
+        @Section(key = "inclusion-settings")
+        public final InclusionSettings inclusionSettings = new InclusionSettings();
+
         @Section(key = "action-settings")
         public final ActionSettings actionSettings = new ActionSettings();
 
@@ -117,6 +120,14 @@ public class FcConfig extends NabConfiguration {
 
             @Entry(key = "metadata")
             public final ConfigEntry<List<String>> metadata = ConfigEntries.stringListEntry();
+
+        }
+
+
+        public static class InclusionSettings extends ConfigSection {
+
+            @Entry(key = "type")
+            public final ConfigEntry<List<String>> type = ConfigEntries.stringListEntry();
 
         }
 

--- a/src/main/java/com/froobworld/farmcontrol/controller/ExclusionManager.java
+++ b/src/main/java/com/froobworld/farmcontrol/controller/ExclusionManager.java
@@ -16,7 +16,9 @@ public class ExclusionManager {
     }
 
     public Predicate<SnapshotEntity> getExclusionPredicate(World world) {
-        FcConfig.WorldSettings.ExclusionSettings exclusionSettings = farmControl.getFcConfig().worldSettings.of(world).exclusionSettings;
+        var cfg = farmControl.getFcConfig().worldSettings.of(world);
+        FcConfig.WorldSettings.ExclusionSettings exclusionSettings = cfg.exclusionSettings;
+        FcConfig.WorldSettings.InclusionSettings inclusionSettings = cfg.inclusionSettings;
         boolean excludeLeashed = exclusionSettings.leashed.get();
         boolean excludeLoveMode = exclusionSettings.loveMode.get();
         List<String> excludeMeta = exclusionSettings.metadata.get();
@@ -27,7 +29,14 @@ public class ExclusionManager {
         long excludeTicksLived = exclusionSettings.youngerThan.get();
         boolean excludePickupable = exclusionSettings.pickupable.get();
         boolean excludeMounted = exclusionSettings.mounted.get();
+        List<String> alwaysIncludeType = inclusionSettings.type.get();
         return snapshotEntity -> {
+            for (String type : alwaysIncludeType) {
+                if (snapshotEntity.getEntityType().toString().equalsIgnoreCase(type)) {
+                    return false;
+                }
+            }
+
             if (excludeLeashed && snapshotEntity.isLeashed()) {
                 return true;
             }

--- a/src/main/resources/resources/config.yml
+++ b/src/main/resources/resources/config.yml
@@ -94,6 +94,13 @@ world-settings:
         - trident
       #  - villager
 
+    inclusion-settings:
+      # Which types of mobs should we always perform actions on,
+      # even if they would normally be excluded by the exclusion settings?
+      type:
+        - villager
+
+
       # For which metadata should we not perform actions on a mob?
       #  * Some plugins will add metadata to mobs that they spawn or use. This setting allows you to exclude those mobs
       #    from having actions performed on them by this plugin.


### PR DESCRIPTION
Adds a configuration section for always included mob types. This overrides exclusion settings for the specific entity type